### PR TITLE
[5.3.0] Add cumulus user to sudo group

### DIFF
--- a/Dockerfile-5.3.0
+++ b/Dockerfile-5.3.0
@@ -1,11 +1,11 @@
-FROM debian:buster
+FROM debian:buster-20221205
 
 ENV container docker
 ENV LC_ALL C
 ENV DEBIAN_FRONTEND noninteractive
 
 # Install systemd :)
-RUN apt update && apt install -y vim systemd udev pciutils sudo tcpdump less util-linux gnupg ca-certificates  
+RUN apt update && apt install -y vim systemd udev pciutils sudo tcpdump less util-linux gnupg ca-certificates
 
 # Copy Cumulus repos and a list of packages
 # NOTE: apt list --installed 2>/dev/null | tail -n +2 | cut -d '/' -f1 > packages
@@ -19,7 +19,7 @@ RUN mkdir -p /usr/lib/systemd/system-preset/
 
 RUN apt update
 
-# Delete unwanted packages 
+# Delete unwanted packages
 RUN  sed -i '/cumulus-docker-setup/d' packages && \
     sed -i '/docker-ce/d' packages && \
     sed -i '/docker-ce-cli/d' packages && \
@@ -46,7 +46,7 @@ RUN apt install --allow-downgrades -y $(cat packages)
 
 # Workaround for watchdog
 RUN apt install -y watchdog || sed -i '/systemctl/d' /var/lib/dpkg/info/watchdog.postinst && \
-    apt install -y watchdog 
+    apt install -y watchdog
 
 # Workaround for nvue
 RUN ln -s /usr/bin/env /bin/env
@@ -66,7 +66,7 @@ RUN echo "echo -n 'x86-cumulus_vx-docker'" > /bin/onie-sysinfo
 RUN chmod +x /bin/onie-sysinfo
 
 # MSTPd workaround
-COPY hacks/mstpd-shot /etc/systemd/system/mstpd-shot.service 
+COPY hacks/mstpd-shot /etc/systemd/system/mstpd-shot.service
 RUN  ln -s  /etc/systemd/system/mstpd-shot.service /etc/systemd/system/multi-user.target.wants/mstpd-shot.service
 
 
@@ -75,7 +75,7 @@ RUN sed -i 's/ExecStart=.*/ExecStart=true/' /lib/systemd/system/aclinit.service
 RUN sed -i 's/ExecStart=.*/ExecStart=true/' /lib/systemd/system/acltool.service
 RUN mkdir -p /etc/cumulus/acl/policy.d/ && \
     rm -rf /etc/cumulus/acl/policy.d/* && \
-    touch /etc/cumulus/acl/policy.d/99control_plane_catch_all.rules 
+    touch /etc/cumulus/acl/policy.d/99control_plane_catch_all.rules
 # This is just to have one rule otherwise net delete all fails
 RUN echo "[ebtables]" >> /etc/cumulus/acl/policy.d/99control_plane_catch_all.rules && \
     echo "-A INPUT -p ipv4 --in-interface swp+ -j ACCEPT" >> /etc/cumulus/acl/policy.d/99control_plane_catch_all.rules
@@ -125,7 +125,7 @@ RUN echo -n "nameserver 8.8.8.8 # vrf mgmt" > /etc/resolv.conf && \
     echo 'make_resolv_conf() { :; }' > /etc/dhcp/dhclient-enter-hooks.d/leave_my_resolv_conf_alone && \
     chmod 755 /etc/dhcp/dhclient-enter-hooks.d/leave_my_resolv_conf_alone
 
-# Reduce dhclient timeout to avoid long startups 
+# Reduce dhclient timeout to avoid long startups
 RUN sed -i 's/#timeout 60;/timeout 2;/' /etc/dhcp/dhclient.conf
 
 # Hack hard-coded file paths
@@ -139,12 +139,12 @@ RUN ln -s /lib/systemd/system/frr.service /etc/systemd/system/multi-user.target.
 RUN rm /etc/systemd/system/multi-user.target.wants/smond.service
 
 # Install PCAP-capable hsflowd
-COPY hacks/hsflowd_2.0.36-2_amd64.deb /tmp 
+COPY hacks/hsflowd_2.0.36-2_amd64.deb /tmp
 RUN apt install -y /tmp/hsflowd_2.0.36-2_amd64.deb
 
 # sysmac workaround
 # COPY hacks/gen_sys_mac.py /usr/lib/cumulus/gen_sys_mac.py
-# COPY hacks/sys-mac-shot /etc/systemd/system/sys-mac-shot.service 
+# COPY hacks/sys-mac-shot /etc/systemd/system/sys-mac-shot.service
 # RUN  ln -s  /etc/systemd/system/sys-mac-shot.service /etc/systemd/system/multi-user.target.wants/sys-mac-shot.service
 
 ENTRYPOINT ["/sbin/init"]

--- a/Dockerfile-5.3.0
+++ b/Dockerfile-5.3.0
@@ -109,6 +109,9 @@ RUN echo "root:root" | chpasswd && \
 RUN useradd -ms /bin/bash cumulus && \
     echo "cumulus:cumulus" | chpasswd
 
+# Add cumulus user to the sudo group
+RUN sudo usermod -aG sudo cumulus
+
 # Enabling remote API access by default
 RUN ln -s /etc/nginx/sites-available/nvue.conf /etc/nginx/sites-enabled/nvue.conf && \
     sed -i 's/listen localhost:8765 ssl;/listen \[::\]:8765 ipv6only=off ssl;/g' /etc/nginx/sites-available/nvue.conf

--- a/Dockerfile-5.3.0
+++ b/Dockerfile-5.3.0
@@ -124,8 +124,7 @@ COPY hacks/sysctl.d/ /etc/sysctl.d/
 COPY hacks/systemd-sysctl.service /lib/systemd/system/systemd-sysctl.service
 
 # Pre-create resolve.conf and stop dhclient from trying to change it
-RUN echo -n "nameserver 8.8.8.8 # vrf mgmt" > /etc/resolv.conf && \
-    echo 'make_resolv_conf() { :; }' > /etc/dhcp/dhclient-enter-hooks.d/leave_my_resolv_conf_alone && \
+RUN echo 'make_resolv_conf() { :; }' > /etc/dhcp/dhclient-enter-hooks.d/leave_my_resolv_conf_alone && \
     chmod 755 /etc/dhcp/dhclient-enter-hooks.d/leave_my_resolv_conf_alone
 
 # Reduce dhclient timeout to avoid long startups


### PR DESCRIPTION
# Description

In Cumulus Linux VX 5.3.0 "cumulus" user is present in the "sudo" group. In the CX 5.3.0 image cumulus is not present in "sudo" group, and because of that, you can use "sudo".  
This PR introduces changes to the 5.3.0 Dockerfile adding "cumulus" to "sudo". Because Dockerfile was created 2 years ago, the latest version of Debian Buster is not compatible with dependencies. I've fixed the base image to Debian Buster version released around the date of the latest CX:5.3.0 build date. Additionally, creation of new resolv.conf was removed, because it's not possible to modify it while it's mounted.


Screen from the Cumulus VX 5.3.0 VM:
![image](https://github.com/user-attachments/assets/9be8b213-40a7-4d72-bc39-108d3011859e)


# Changes
- Add "cumulus" user to "sudo" group
- Fix the version of the base image
- Remove overwriting of "resolv.conf"
- Remove unnecessary whitespace characters